### PR TITLE
Stop referencing IMGLYOperation as a class when it's a protocol

### DIFF
--- a/imglyKit/IMGLYEditorBrightnessViewController.m
+++ b/imglyKit/IMGLYEditorBrightnessViewController.m
@@ -81,7 +81,7 @@ const CGFloat kSliderXMargin = 10.0;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYBrightnessOperation *operation = [[IMGLYBrightnessOperation alloc] init];
     operation.brightness = self.slider.value;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     
     [[IMGLYPhotoProcessor sharedPhotoProcessor] setInputImage:self.inputImage];
     [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
@@ -95,7 +95,7 @@ const CGFloat kSliderXMargin = 10.0;
 	    IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
         IMGLYBrightnessOperation *operation = [[IMGLYBrightnessOperation alloc] init];
         operation.brightness = self.slider.value;
-        [job addOperation:(IMGLYOperation *)operation];
+        [job addOperation:operation];
         self.completionHandler(IMGLYEditorViewControllerResultDone,self.imagePreview.image, job);
     }
 }

--- a/imglyKit/IMGLYEditorContrastViewController.m
+++ b/imglyKit/IMGLYEditorContrastViewController.m
@@ -80,7 +80,7 @@ extern CGFloat kSliderXMargin;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYContrastOperation *operation = [[IMGLYContrastOperation alloc] init];
     operation.contrast = self.slider.value;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     [[IMGLYPhotoProcessor sharedPhotoProcessor] setInputImage:self.inputImage];
     [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
     self.imagePreview.image = [[IMGLYPhotoProcessor sharedPhotoProcessor] outputImage];
@@ -93,7 +93,7 @@ extern CGFloat kSliderXMargin;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYContrastOperation *operation = [[IMGLYContrastOperation alloc] init];
     operation.contrast = self.slider.value;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     self.completionHandler(IMGLYEditorViewControllerResultDone,self.imagePreview.image, job);
 }
 @end

--- a/imglyKit/IMGLYEditorCropViewController.m
+++ b/imglyKit/IMGLYEditorCropViewController.m
@@ -712,7 +712,7 @@ static const CGFloat kBackgroundGrayValue =  34.0 / 255.0;
         IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
         IMGLYCropOperation *operation = [[IMGLYCropOperation alloc] init];
         operation.rect = [self normalizedCropRect];
-        [job addOperation:(IMGLYOperation *)operation];
+        [job addOperation:operation];
         [[IMGLYPhotoProcessor sharedPhotoProcessor] setInputImage:self.inputImage];
         [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
         self.completionHandler(IMGLYEditorViewControllerResultDone,

--- a/imglyKit/IMGLYEditorEnhancementViewcontroller.m
+++ b/imglyKit/IMGLYEditorEnhancementViewcontroller.m
@@ -100,7 +100,7 @@
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYEnhancementOperation *enhancementOperation = [[IMGLYEnhancementOperation alloc] init];
 
-    [job addOperation:(IMGLYOperation *)enhancementOperation];
+    [job addOperation:enhancementOperation];
     return job;
 }
 

--- a/imglyKit/IMGLYEditorFilterViewController.m
+++ b/imglyKit/IMGLYEditorFilterViewController.m
@@ -105,7 +105,7 @@ extern CGFloat const kEditorMenuViewHeight;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYFilterOperation *operation = [[IMGLYFilterOperation alloc] init];
     operation.filterType = self.currentFilterType;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     return job;
 }
 

--- a/imglyKit/IMGLYEditorFocusViewController.m
+++ b/imglyKit/IMGLYEditorFocusViewController.m
@@ -165,7 +165,7 @@ static const CGFloat kMenuViewHeight = 95.0;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYGaussOperation *operation = [[IMGLYGaussOperation alloc] init];
     
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     
     [[IMGLYPhotoProcessor sharedPhotoProcessor] setInputImage:self.inputImage];
     [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
@@ -194,7 +194,7 @@ static const CGFloat kMenuViewHeight = 95.0;
         operation.scaleVector = CGPointMake(1.0, self.imagePreview.image.size.height / self.imagePreview.image.size.width);
     }
     
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     return job;
 }
 

--- a/imglyKit/IMGLYEditorNoiseViewController.m
+++ b/imglyKit/IMGLYEditorNoiseViewController.m
@@ -124,7 +124,7 @@ const static CGFloat kMaximumNoiseValue = 0.5;
     IMGLYNoiseOperation *operation = [[IMGLYNoiseOperation alloc] init];
     operation.intensity = value;
     operation.noiseImage = self.noiseImage;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     return job;
 }
 
@@ -133,7 +133,7 @@ const static CGFloat kMaximumNoiseValue = 0.5;
     IMGLYNoiseOperation *operation = [[IMGLYNoiseOperation alloc] init];
     operation.intensity = value;
     operation.noiseImage = nil;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     return job;
 }
 

--- a/imglyKit/IMGLYEditorOrientationViewController.m
+++ b/imglyKit/IMGLYEditorOrientationViewController.m
@@ -63,7 +63,7 @@ static const CGFloat kMenuViewHeight = 95.0;
 
 - (IMGLYProcessingJob *) processingJob {
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
-    [job addOperation:(IMGLYOperation *)self.operation];
+    [job addOperation:self.operation];
     return job;
 }
 

--- a/imglyKit/IMGLYEditorSaturationViewController.m
+++ b/imglyKit/IMGLYEditorSaturationViewController.m
@@ -78,7 +78,7 @@ extern CGFloat kSliderXMargin;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYSaturationOperation *operation = [[IMGLYSaturationOperation alloc] init];
     operation.saturation  = self.slider.value;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     [[IMGLYPhotoProcessor sharedPhotoProcessor] setInputImage:self.inputImage];
     [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
     self.imagePreview.image = [[IMGLYPhotoProcessor sharedPhotoProcessor] outputImage];
@@ -91,7 +91,7 @@ extern CGFloat kSliderXMargin;
     IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
     IMGLYSaturationOperation *operation = [[IMGLYSaturationOperation alloc] init];
     operation.saturation = self.slider.value;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     self.completionHandler(IMGLYEditorViewControllerResultDone,self.imagePreview.image, job);
 }
 

--- a/imglyKit/IMGLYEditorTextViewController.m
+++ b/imglyKit/IMGLYEditorTextViewController.m
@@ -273,7 +273,7 @@ static const CGFloat kTextLabelInitialMargin = 40.0;
     operation.fontName = self.fontName;
     operation.position = [self transformedTextPosition];
     operation.color = self.textLabel.textColor;
-    [job addOperation:(IMGLYOperation *)operation];
+    [job addOperation:operation];
     return job;
 }
 

--- a/imglyKit/IMGLYEditorViewController.m
+++ b/imglyKit/IMGLYEditorViewController.m
@@ -204,7 +204,7 @@ static const CGFloat kEditorMainMenuViewHeight = 95;
 - (void)addJobForInitialFilterType:(IMGLYFilterType)filterType {
     IMGLYFilterOperation *operation = [[IMGLYFilterOperation alloc] init];
     operation.filterType = filterType;
-    [_finalProcessingJob addOperation:(IMGLYOperation *)operation];
+    [_finalProcessingJob addOperation:operation];
 }
 
 - (void)resetAllChanges {
@@ -237,7 +237,7 @@ static const CGFloat kEditorMainMenuViewHeight = 95;
         self.imagePreview.image = self.previewImage;
     }
     
-    for (IMGLYOperation *operation in job.operations) {
+    for (id<IMGLYOperation>operation in job.operations) {
         [self.finalProcessingJob addOperation:operation];
     }
 }
@@ -323,7 +323,7 @@ static const CGFloat kEditorMainMenuViewHeight = 95;
             IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
             IMGLYEnhancementOperation *enhancementOperation = [[IMGLYEnhancementOperation alloc] init];
 
-            [job addOperation:(IMGLYOperation *)enhancementOperation];
+            [job addOperation:enhancementOperation];
             [[IMGLYPhotoProcessor sharedPhotoProcessor] setInputImage:strongSelf.nonEnhancedImage];
             [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job ];
             strongSelf.enhancedImage = [[IMGLYPhotoProcessor sharedPhotoProcessor] outputImage];

--- a/imglyKit/IMGLYFilterSelectorView.m
+++ b/imglyKit/IMGLYFilterSelectorView.m
@@ -461,7 +461,7 @@ const CGFloat kActivationDuration = 0.15f;
             IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
             IMGLYFilterOperation *operation = [[IMGLYFilterOperation alloc] init];
             operation.filterType = filterSelectorButtonMetadata.filterType;
-            [job addOperation:(IMGLYOperation *)operation];
+            [job addOperation:operation];
             [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
             UIImage *filtredImage = [[IMGLYPhotoProcessor sharedPhotoProcessor] outputImage];
             dispatch_sync(dispatch_get_main_queue(), ^{
@@ -483,7 +483,7 @@ const CGFloat kActivationDuration = 0.15f;
         IMGLYProcessingJob *job = [[IMGLYProcessingJob alloc] init];
         IMGLYFilterOperation *operation = [[IMGLYFilterOperation alloc] init];
         operation.filterType = filterSelectorButtonMetadata.filterType;
-        [job addOperation:(IMGLYOperation *)operation];
+        [job addOperation:operation];
         [[IMGLYPhotoProcessor sharedPhotoProcessor] performProcessingJob:job];
         UIImage *filtredImage = [[IMGLYPhotoProcessor sharedPhotoProcessor] outputImage];
         filterSelectorButtonMetadata.staticPreviewImage = filtredImage;

--- a/imglyKit/IMGLYProcessingJob.h
+++ b/imglyKit/IMGLYProcessingJob.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class IMGLYOperation;
+@protocol IMGLYOperation;
 
 /**
  A processing job encapsulates operations that an IMGLYPhotoProcessor can process.
@@ -17,6 +17,6 @@
 
 @property (nonatomic, strong, readonly) NSArray *operations;
 
-- (void)addOperation:(IMGLYOperation *)operation;
+- (void)addOperation:(id <IMGLYOperation>)operation;
 
 @end

--- a/imglyKit/IMGLYProcessingJob.m
+++ b/imglyKit/IMGLYProcessingJob.m
@@ -28,7 +28,7 @@
     return self;
 }
 
-- (void)addOperation:(IMGLYOperation *)operation {
+- (void)addOperation:(id<IMGLYOperation>)operation {
     [self.internalOperations addObject:operation];
 }
 


### PR DESCRIPTION
Fix warnings related to class/protocol confusion.