### PR TITLE
Fix public visibility to allow add/replace of stickers

### DIFF
--- a/imglyKit/Frontend/Editor/IMGLYSticker.swift
+++ b/imglyKit/Frontend/Editor/IMGLYSticker.swift
@@ -12,7 +12,7 @@ public class IMGLYSticker: NSObject {
     public let image: UIImage
     public let thumbnail: UIImage?
     
-    init(image: UIImage, thumbnail: UIImage?) {
+    public init(image: UIImage, thumbnail: UIImage?) {
         self.image = image
         self.thumbnail = thumbnail
         super.init()

--- a/imglyKit/Frontend/Editor/IMGLYStickersDataSource.swift
+++ b/imglyKit/Frontend/Editor/IMGLYStickersDataSource.swift
@@ -48,7 +48,7 @@ public class IMGLYStickersDataSource: NSObject, IMGLYStickersDataSourceDelegate 
         super.init()
     }
     
-    init(stickers: [IMGLYSticker]) {
+    public init(stickers: [IMGLYSticker]) {
         self.stickers = stickers
         super.init()
     }

--- a/imglyKit/Frontend/Editor/IMGLYStickersEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/IMGLYStickersEditorViewController.swift
@@ -15,7 +15,7 @@ public class IMGLYStickersEditorViewController: IMGLYSubEditorViewController {
 
     // MARK: - Properties
     
-    public let stickersDataSource = IMGLYStickersDataSource()
+    public var stickersDataSource = IMGLYStickersDataSource()
     public private(set) lazy var stickersClipView: UIView = {
         let view = UIView()
         view.clipsToBounds = true


### PR DESCRIPTION
I have try to create a subclass of IMGLYStickersEditorViewController but it wasn't possible to add custom stickers.

With this PR is possible also to customize sticker in IMGLYStickersEditorViewController replacing stickersDataSource 