### PR TITLE
Fix wrong view positioning of pushed VCs

### DIFF
--- a/imglyKit/Frontend/Editor/NavigationAnimationController.swift
+++ b/imglyKit/Frontend/Editor/NavigationAnimationController.swift
@@ -24,6 +24,8 @@ extension NavigationAnimationController: UIViewControllerAnimatedTransitioning {
             let toView = toViewController.view
             let fromView = fromViewController.view
 
+            toView.frame = fromView.frame
+
             let containerView = transitionContext.containerView()
             containerView?.addSubview(toView)
             containerView?.sendSubviewToBack(toView)


### PR DESCRIPTION
When pushing a view controller from the `MainEditorViewController`, the pushed view controller's view was misplaced and extended below the navigation bar.