### PR TITLE
Fix handling of low resolution images

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,4 @@ disabled_rules:
   - function_body_length
   - type_body_length
   - valid_docs
+  - cyclomatic_complexity

--- a/imglyKit/Frontend/Camera/FlashController.swift
+++ b/imglyKit/Frontend/Camera/FlashController.swift
@@ -67,7 +67,7 @@ final class FlashController: NSObject, LightControllable {
         while !videoDeviceInput.device.isFlashModeSupported(AVCaptureFlashMode(lightMode: nextFlashMode)) {
             nextFlashModeIndex = (nextFlashModeIndex + 1) % lightModes.count
             nextFlashMode = lightModes[nextFlashModeIndex]
-            counter++
+            counter += 1
 
             if counter >= lightModes.count {
                 nextFlashMode = .Off

--- a/imglyKit/Frontend/Camera/TorchController.swift
+++ b/imglyKit/Frontend/Camera/TorchController.swift
@@ -71,7 +71,7 @@ final class TorchController: NSObject, LightControllable {
         while !videoDeviceInput.device.isTorchModeSupported(AVCaptureTorchMode(lightMode: nextTorchMode)) {
             nextTorchModeIndex = (nextTorchModeIndex + 1) % lightModes.count
             nextTorchMode = lightModes[nextTorchModeIndex]
-            counter++
+            counter += 1
 
             if counter >= lightModes.count {
                 nextTorchMode = .Off

--- a/imglyKit/Frontend/Configuration/Options/CameraViewControllerOptions.swift
+++ b/imglyKit/Frontend/Configuration/Options/CameraViewControllerOptions.swift
@@ -37,10 +37,10 @@ public typealias RecordingModeButtonConfigurationClosure = (UIButton, RecordingM
     /// Use this closure to configure the timelabel.
     public let timeLabelConfigurationClosure: LabelConfigurationClosure?
 
-    // swiftlint:disable variable_name_max_length
+    // swiftlint:disable variable_name
     /// Use this closure to configure the filter intensity slider.
     public let filterIntensitySliderConfigurationClosure: SliderConfigurationClosure?
-    // swiftlint:enable variable_name_max_length
+    // swiftlint:enable variable_name
 
     /// Use this closure to configure the given recording mode button. By default the buttons
     /// light up in yellow, when selected.
@@ -141,10 +141,10 @@ public typealias RecordingModeButtonConfigurationClosure = (UIButton, RecordingM
     /// Use this closure to configure the timelabel. Defaults to an empty implementation.
     public var timeLabelConfigurationClosure: LabelConfigurationClosure? = nil
 
-    // swiftlint:disable variable_name_max_length
+    // swiftlint:disable variable_name
     /// Use this closure to configure the filter intensity slider. Defaults to an empty implementation.
     public var filterIntensitySliderConfigurationClosure: SliderConfigurationClosure? = nil
-    // swiftlint:enable variable_name_max_length
+    // swiftlint:enable variable_name
 
     /// Use this closure to configure the given recording mode button. By default the buttons
     /// light up in yellow, when selected.

--- a/imglyKit/Frontend/Configuration/Options/FilterEditorViewControllerOptions.swift
+++ b/imglyKit/Frontend/Configuration/Options/FilterEditorViewControllerOptions.swift
@@ -12,11 +12,11 @@ import UIKit
 
     // MARK: UI
 
-    // swiftlint:disable variable_name_max_length
+    // swiftlint:disable variable_name
     /// Use this closure to configure the filter intensity slider.
     /// Defaults to an empty implementation.
     public let filterIntensitySliderConfigurationClosure: SliderConfigurationClosure?
-    // swiftlint:enable variable_name_max_length
+    // swiftlint:enable variable_name
 
     /// An object conforming to the `FiltersDataSourceProtocol`
     /// Per default an `FilterSelectionControllerDataSource` offering all filters
@@ -42,11 +42,11 @@ import UIKit
 @objc(IMGLYFilterEditorViewControllerOptionsBuilder) public class FilterEditorViewControllerOptionsBuilder: EditorViewControllerOptionsBuilder {
     // swiftlint:enable type_name
 
-    // swiftlint:disable variable_name_max_length
+    // swiftlint:disable variable_name
     /// Use this closure to configure the filter intensity slider.
     /// Defaults to an empty implementation.
     public var filterIntensitySliderConfigurationClosure: SliderConfigurationClosure? = nil
-    // swiftlint:enable variable_name_max_length
+    // swiftlint:enable variable_name
 
     /// An object conforming to the `FiltersDataSourceProtocol`
     /// Per default an `FilterSelectionControllerDataSource` offering all filters

--- a/imglyKit/Frontend/Editor/CropEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/CropEditorViewController.swift
@@ -155,7 +155,7 @@ public let kMinimumCropSize = CGFloat(50)
 
     public override func zoomingImageViewDidZoom(zoomingImageView: ZoomingImageView) {
         super.zoomingImageViewDidZoom(zoomingImageView)
-        
+
         transparentRectView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
         reCalculateCropRectBounds()
     }

--- a/imglyKit/Frontend/Editor/CropEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/CropEditorViewController.swift
@@ -143,13 +143,6 @@ public let kMinimumCropSize = CGFloat(50)
         }
     }
 
-    public override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        transparentRectView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
-        reCalculateCropRectBounds()
-    }
-
     // MARK: - EditorViewController
 
     public override var options: CropEditorViewControllerOptions {
@@ -158,6 +151,13 @@ public let kMinimumCropSize = CGFloat(50)
 
     override var enableZoomingInPreviewImage: Bool {
         return false
+    }
+
+    public override func zoomingImageViewDidZoom(zoomingImageView: ZoomingImageView) {
+        super.zoomingImageViewDidZoom(zoomingImageView)
+        
+        transparentRectView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
+        reCalculateCropRectBounds()
     }
 
     // MARK: - SubEditorViewController

--- a/imglyKit/Frontend/Editor/CropEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/CropEditorViewController.swift
@@ -156,6 +156,10 @@ public let kMinimumCropSize = CGFloat(50)
         return self.configuration.cropEditorViewControllerOptions
     }
 
+    override var enableZoomingInPreviewImage: Bool {
+        return false
+    }
+
     // MARK: - SubEditorViewController
 
     public override func tappedDone(sender: UIBarButtonItem?) {
@@ -192,7 +196,6 @@ public let kMinimumCropSize = CGFloat(50)
             viewNames.append(viewName)
             buttonContainerView.addSubview(button)
             views[viewName] = button
-            print(viewName)
             buttonContainerView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[\(viewName)]|", options: [], metrics: nil, views: views))
         }
 

--- a/imglyKit/Frontend/Editor/EditorViewController.swift
+++ b/imglyKit/Frontend/Editor/EditorViewController.swift
@@ -44,6 +44,7 @@ internal let kPhotoProcessorQueue = dispatch_queue_create("ly.img.SDK.PhotoProce
         imageView.backgroundColor = self.currentBackgroundColor
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.userInteractionEnabled = self.enableZoomingInPreviewImage
+        imageView.zoomDelegate = self
         return imageView
         }()
 
@@ -171,5 +172,10 @@ internal let kPhotoProcessorQueue = dispatch_queue_create("ly.img.SDK.PhotoProce
     public func tappedDone(sender: UIBarButtonItem?) {
         // Subclasses must override this
     }
+}
 
+extension EditorViewController: ZoomingImageViewDelegate {
+    public func zoomingImageViewDidZoom(zoomingImageView: ZoomingImageView) {
+        // Subclasses can override this
+    }
 }

--- a/imglyKit/Frontend/Editor/FocusEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/FocusEditorViewController.swift
@@ -94,6 +94,16 @@ import UIKit
         return false
     }
 
+    public override func zoomingImageViewDidZoom(zoomingImageView: ZoomingImageView) {
+        super.zoomingImageViewDidZoom(zoomingImageView)
+        
+        circleGradientView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
+        circleGradientView.centerGUIElements()
+
+        boxGradientView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
+        boxGradientView.centerGUIElements()
+    }
+
     // MARK: - UIViewController
 
     override public func viewDidLoad() {
@@ -107,16 +117,6 @@ import UIKit
             fixedFilterStack.tiltShiftFilter.tiltShiftType = .Off
             updatePreviewImage()
         }
-    }
-
-    public override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        circleGradientView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
-        circleGradientView.centerGUIElements()
-
-        boxGradientView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
-        boxGradientView.centerGUIElements()
     }
 
     // MARK: - Configuration

--- a/imglyKit/Frontend/Editor/FocusEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/FocusEditorViewController.swift
@@ -90,6 +90,10 @@ import UIKit
         return self.configuration.focusEditorViewControllerOptions
     }
 
+    override var enableZoomingInPreviewImage: Bool {
+        return false
+    }
+
     // MARK: - UIViewController
 
     override public func viewDidLoad() {

--- a/imglyKit/Frontend/Editor/FocusEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/FocusEditorViewController.swift
@@ -96,7 +96,7 @@ import UIKit
 
     public override func zoomingImageViewDidZoom(zoomingImageView: ZoomingImageView) {
         super.zoomingImageViewDidZoom(zoomingImageView)
-        
+
         circleGradientView.frame = view.convertRect(previewImageView.visibleImageFrame, fromView: previewImageView)
         circleGradientView.centerGUIElements()
 

--- a/imglyKit/Frontend/Editor/OverlayConverter.swift
+++ b/imglyKit/Frontend/Editor/OverlayConverter.swift
@@ -47,7 +47,6 @@ import UIKit
         completeSize.height *= 1.0 / cropRect.height
         let size = stickerFilter.absolutStickerSizeForImageSize(completeSize)
         imageView.frame.size = size
-        print(stickerFilter.center)
         var center = CGPoint(x: stickerFilter.center.x * completeSize.width,
             y: stickerFilter.center.y * completeSize.height)
         center.x -= (cropRect.origin.x * completeSize.width)

--- a/imglyKit/Frontend/Editor/SaturationBrightnessPickerView.swift
+++ b/imglyKit/Frontend/Editor/SaturationBrightnessPickerView.swift
@@ -26,7 +26,6 @@ import UIKit
             hue = hsb.hue
             brightness = hsb.brightness
             saturation = hsb.saturation
-            print(hue, brightness, saturation)
             setNeedsDisplay()
         }
         get {

--- a/imglyKit/Frontend/Editor/StickersEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/StickersEditorViewController.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 let kStickersCollectionViewCellSize = CGSize(width: 90, height: 90)
-// swiftlint:disable variable_name_max_length
+// swiftlint:disable variable_name
 let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
-// swiftlint:enable variable_name_max_length
+// swiftlint:enable variable_name
 
 @objc(IMGLYStickersEditorViewController) public class StickersEditorViewController: SubEditorViewController {
 

--- a/imglyKit/Frontend/Editor/StickersEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/StickersEditorViewController.swift
@@ -34,6 +34,10 @@ let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
         return self.configuration.stickersEditorViewControllerOptions
     }
 
+    override var enableZoomingInPreviewImage: Bool {
+        return false
+    }
+
     // MARK: - SubEditorViewController
 
     public override func tappedDone(sender: UIBarButtonItem?) {

--- a/imglyKit/Frontend/Editor/StickersEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/StickersEditorViewController.swift
@@ -41,7 +41,7 @@ let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
     // MARK: - SubEditorViewController
 
     public override func tappedDone(sender: UIBarButtonItem?) {
-        let addedStickers =         self.overlayConverter?.addSpriteFiltersFromUIElements(stickersClipView, previewSize: previewImageView.visibleImageFrame.size, previewImage: previewImageView.image!)
+        let addedStickers = self.overlayConverter?.addSpriteFiltersFromUIElements(stickersClipView, previewSize: previewImageView.visibleImageFrame.size, previewImage: previewImageView.image!)
         if addedStickers != nil {
             updatePreviewImageWithCompletion {
                 self.stickersClipView.removeFromSuperview()

--- a/imglyKit/Frontend/Editor/TextEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/TextEditorViewController.swift
@@ -173,7 +173,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     override var enableZoomingInPreviewImage: Bool {
         return false
     }
-    
+
     // MARK: - SubEditorViewController
 
     public override func tappedDone(sender: UIBarButtonItem?) {

--- a/imglyKit/Frontend/Editor/TextEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/TextEditorViewController.swift
@@ -170,6 +170,10 @@ private let kMinimumFontSize = CGFloat(12.0)
         return self.configuration.textEditorViewControllerOptions
     }
 
+    override var enableZoomingInPreviewImage: Bool {
+        return false
+    }
+    
     // MARK: - SubEditorViewController
 
     public override func tappedDone(sender: UIBarButtonItem?) {


### PR DESCRIPTION
When using the editor with an image that was smaller than the editors bounds, some editors did not function correctly (e.g. crop and focus). This fixes #62.