### PR TITLE
Improve performance of stickers and text

### DIFF
--- a/imglyKit.xcodeproj/project.pbxproj
+++ b/imglyKit.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		2B67D1C81C47DBED00BEE726 /* LightController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B67D1C71C47DBED00BEE726 /* LightController.swift */; };
 		2B6D88F41C4509F500200557 /* TorchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6D88F31C4509F500200557 /* TorchController.swift */; };
 		2B6D88F61C452B9900200557 /* DeviceOrientationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6D88F51C452B9900200557 /* DeviceOrientationController.swift */; };
+		2B948C351C5B6A0900094CAE /* CGAffineTransformExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B948C341C5B6A0900094CAE /* CGAffineTransformExtension.swift */; };
+		2B948C361C5B6A0900094CAE /* CGAffineTransformExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B948C341C5B6A0900094CAE /* CGAffineTransformExtension.swift */; };
 		2BA980601C493FE7001C85B6 /* VideoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA9805F1C493FE7001C85B6 /* VideoController.swift */; };
 		2BB88C3E1B69127400D23A2F /* ScaleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB88C3D1B69127400D23A2F /* ScaleFilter.swift */; };
 		2BB88C3F1B69127400D23A2F /* ScaleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB88C3D1B69127400D23A2F /* ScaleFilter.swift */; };
@@ -458,6 +460,7 @@
 		2B67D1C71C47DBED00BEE726 /* LightController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LightController.swift; sourceTree = "<group>"; };
 		2B6D88F31C4509F500200557 /* TorchController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TorchController.swift; sourceTree = "<group>"; };
 		2B6D88F51C452B9900200557 /* DeviceOrientationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceOrientationController.swift; sourceTree = "<group>"; };
+		2B948C341C5B6A0900094CAE /* CGAffineTransformExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtension.swift; sourceTree = "<group>"; };
 		2BA9805F1C493FE7001C85B6 /* VideoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoController.swift; sourceTree = "<group>"; };
 		2BB88C3D1B69127400D23A2F /* ScaleFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScaleFilter.swift; sourceTree = "<group>"; };
 		2BBE166B1C4E44FA00921DE7 /* FocusController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FocusController.swift; sourceTree = "<group>"; };
@@ -781,6 +784,7 @@
 		2B1ADA0E1B19C36E00C98522 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				2B948C341C5B6A0900094CAE /* CGAffineTransformExtension.swift */,
 				2B1ADAE31B19D0C800C98522 /* NSAffineTransformExtension.swift */,
 				2B1ADAE11B19CD5500C98522 /* NSImageExtension.swift */,
 			);
@@ -1554,6 +1558,7 @@
 				2B1ADACF1B19C8EE00C98522 /* Pro400Filter.swift in Sources */,
 				2B1ADAA31B19C8EE00C98522 /* BlueShadowsFilter.swift in Sources */,
 				2B1ADAB41B19C8EE00C98522 /* FridgeFilter.swift in Sources */,
+				2B948C361C5B6A0900094CAE /* CGAffineTransformExtension.swift in Sources */,
 				2B1ADACA1B19C8EE00C98522 /* PitchedFilter.swift in Sources */,
 				2B1ADAD01B19C8EE00C98522 /* QuoziFilter.swift in Sources */,
 				2B1ADADB1B19C8EE00C98522 /* TenderFilter.swift in Sources */,
@@ -1696,6 +1701,7 @@
 				2BF4D5181AF1155E00C801B2 /* KeenFilter.swift in Sources */,
 				2BF4D3E21AF1150500C801B2 /* SaturationEditorViewController.swift in Sources */,
 				2BF4D3D11AF1150500C801B2 /* ColorButton.swift in Sources */,
+				2B948C351C5B6A0900094CAE /* CGAffineTransformExtension.swift in Sources */,
 				098331121C3FB511000135B8 /* SaturationBrightnessPickerView.swift in Sources */,
 				2BF4D5361AF1155E00C801B2 /* TenderFilter.swift in Sources */,
 				2BC537971C513A2900A7DE17 /* CropEditorViewControllerOptions.swift in Sources */,

--- a/imglyKit/Backend/Extensions/CGAffineTransformExtension.swift
+++ b/imglyKit/Backend/Extensions/CGAffineTransformExtension.swift
@@ -1,0 +1,23 @@
+//
+//  CGAffineTransformExtension.swift
+//  imglyKit
+//
+//  Created by Sascha Schwabbauer on 29/01/16.
+//  Copyright © 2016 9elements GmbH. All rights reserved.
+//
+
+import CoreImage
+
+extension CGAffineTransform {
+    var xScale: CGFloat {
+        return sqrt(a * a + c * c)
+    }
+
+    var yScale: CGFloat {
+        return sqrt(b * b + d * d)
+    }
+
+    var rotation: CGFloat {
+        return atan2(b, a)
+    }
+}

--- a/imglyKit/Backend/Processing/PhotoProcessor.swift
+++ b/imglyKit/Backend/Processing/PhotoProcessor.swift
@@ -97,6 +97,7 @@ All types of response-filters.
         for filter in filters {
             filter.inputImage = currentImage
             currentImage = filter.outputImage
+            filter.inputImage = nil
         }
 
         if let currentImage = currentImage where CGRectIsEmpty(currentImage.extent) {
@@ -113,10 +114,11 @@ All types of response-filters.
         guard let coreImage = CIImage(image: image) else {
             return nil
         }
+
         var options = [String: AnyObject]()
 
         if let colorspace = CGColorSpaceCreateDeviceRGB() {
-            options = [kCIContextWorkingColorSpace: colorspace]
+            options[kCIContextWorkingColorSpace] = colorspace
         }
 
         let filteredCIImage = processWithCIImage(coreImage, filters: filters)

--- a/imglyKit/Backend/Processing/StickerFilter.swift
+++ b/imglyKit/Backend/Processing/StickerFilter.swift
@@ -66,8 +66,13 @@ import CoreGraphics
         return filter.outputImage
     }
 
-    public func absolutStickerSizeForImageSize(imageSize: CGSize) -> CGSize {
+    public func absoluteStickerSizeForImageSize(imageSize: CGSize) -> CGSize {
         let stickerRatio = sticker!.size.height / sticker!.size.width
+
+        if imageSize.width > imageSize.height {
+            return CGSize(width: self.scale * imageSize.height, height: self.scale * stickerRatio * imageSize.height)
+        }
+
         return CGSize(width: self.scale * imageSize.width, height: self.scale * stickerRatio * imageSize.width)
     }
 
@@ -82,7 +87,7 @@ import CoreGraphics
         let inputImageSize = inputImageRect.size
 
         let originalInputImageSize = CGSize(width: round(inputImageSize.width / cropRect.width), height: round(inputImageSize.height / cropRect.height))
-        let absoluteStickerSize = absolutStickerSizeForImageSize(originalInputImageSize)
+        let absoluteStickerSize = absoluteStickerSizeForImageSize(originalInputImageSize)
 
         let stickerImageSize = image.extent.size
         let stickerScale = absoluteStickerSize.width / stickerImageSize.width
@@ -103,7 +108,7 @@ import CoreGraphics
         // Translate
         // Calculate the origin of the sticker. Note that in CoreImage (0,0) is at the bottom
         let stickerOrigin = CGPoint(x: stickerCenter.x - absoluteStickerSize.width * xScale / 2, y: stickerCenter.y + absoluteStickerSize.height * yScale / 2)
-        transform = CGAffineTransformTranslate(transform, stickerOrigin.x / stickerScale, (originalInputImageSize.height - stickerOrigin.y) / stickerScale)
+        transform = CGAffineTransformTranslate(transform, stickerOrigin.x / stickerScale, (inputImageSize.height - stickerOrigin.y) / stickerScale)
 
         // Scale
         transform = CGAffineTransformScale(transform, xScale, yScale)

--- a/imglyKit/Backend/Processing/StickerFilter.swift
+++ b/imglyKit/Backend/Processing/StickerFilter.swift
@@ -69,6 +69,7 @@ import CoreGraphics
     public func absoluteStickerSizeForImageSize(imageSize: CGSize) -> CGSize {
         let stickerRatio = sticker!.size.height / sticker!.size.width
 
+        // TODO: Fix this
         if imageSize.width > imageSize.height {
             return CGSize(width: self.scale * imageSize.height, height: self.scale * stickerRatio * imageSize.height)
         }
@@ -90,7 +91,8 @@ import CoreGraphics
         let absoluteStickerSize = absoluteStickerSizeForImageSize(originalInputImageSize)
 
         let stickerImageSize = image.extent.size
-        let stickerScale = absoluteStickerSize.width / stickerImageSize.width
+        let stickerScaleX = absoluteStickerSize.width / stickerImageSize.width
+        let stickerScaleY = absoluteStickerSize.height / stickerImageSize.height
 
         var stickerCenter = CGPoint(x: center.x * originalInputImageSize.width, y: center.y * originalInputImageSize.height)
         stickerCenter.x -= (cropRect.origin.x * originalInputImageSize.width)
@@ -103,12 +105,12 @@ import CoreGraphics
         var transform = CGAffineTransformIdentity
 
         // Scale to match size of preview
-        transform = CGAffineTransformScale(transform, stickerScale, stickerScale)
+        transform = CGAffineTransformScale(transform, stickerScaleX, stickerScaleY)
 
         // Translate
         // Calculate the origin of the sticker. Note that in CoreImage (0,0) is at the bottom
         let stickerOrigin = CGPoint(x: stickerCenter.x - absoluteStickerSize.width * xScale / 2, y: stickerCenter.y + absoluteStickerSize.height * yScale / 2)
-        transform = CGAffineTransformTranslate(transform, stickerOrigin.x / stickerScale, (inputImageSize.height - stickerOrigin.y) / stickerScale)
+        transform = CGAffineTransformTranslate(transform, stickerOrigin.x / stickerScaleX, (inputImageSize.height - stickerOrigin.y) / stickerScaleY)
 
         // Scale
         transform = CGAffineTransformScale(transform, xScale, yScale)

--- a/imglyKit/Backend/Processing/StickerFilter.swift
+++ b/imglyKit/Backend/Processing/StickerFilter.swift
@@ -57,15 +57,12 @@ import CoreGraphics
             return inputImage
         }
 
-        let stickerImage = createStickerImage()
-
-        guard let cgImage = stickerImage.CGImage, filter = CIFilter(name: "CISourceOverCompositing") else {
+        guard let filter = CIFilter(name: "CISourceOverCompositing"), sticker = createStickerImage() else {
             return inputImage
         }
 
-        let stickerCIImage = CIImage(CGImage: cgImage)
         filter.setValue(inputImage, forKey: kCIInputBackgroundImageKey)
-        filter.setValue(stickerCIImage, forKey: kCIInputImageKey)
+        filter.setValue(sticker, forKey: kCIInputImageKey)
         return filter.outputImage
     }
 
@@ -74,47 +71,55 @@ import CoreGraphics
         return CGSize(width: self.scale * imageSize.width, height: self.scale * stickerRatio * imageSize.width)
     }
 
-    #if os(iOS)
-
-    private func createStickerImage() -> UIImage {
-        let rect = inputImage!.extent
-        let imageSize = rect.size
-        UIGraphicsBeginImageContext(imageSize)
-        UIColor(white: 1.0, alpha: 0.0).setFill()
-        UIRectFill(CGRect(origin: CGPoint(), size: imageSize))
-
-        if let context = UIGraphicsGetCurrentContext() {
-            drawStickerInContext(context, withImageOfSize: imageSize)
+    private func createStickerImage() -> CIImage? {
+        guard let cgImage = sticker?.CGImage else {
+            return nil
         }
 
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+        var image = CIImage(CGImage: cgImage)
+
+        let inputImageRect = inputImage!.extent
+        let inputImageSize = inputImageRect.size
+
+        let originalInputImageSize = CGSize(width: round(inputImageSize.width / cropRect.width), height: round(inputImageSize.height / cropRect.height))
+        let absoluteStickerSize = absolutStickerSizeForImageSize(originalInputImageSize)
+
+        let stickerImageSize = image.extent.size
+        let stickerScale = absoluteStickerSize.width / stickerImageSize.width
+
+        var stickerCenter = CGPoint(x: center.x * originalInputImageSize.width, y: center.y * originalInputImageSize.height)
+        stickerCenter.x -= (cropRect.origin.x * originalInputImageSize.width)
+        stickerCenter.y -= (cropRect.origin.y * originalInputImageSize.height)
+
+        let xScale = self.transform.xScale
+        let yScale = self.transform.yScale
+        let rotation = self.transform.rotation
+
+        var transform = CGAffineTransformIdentity
+
+        // Scale to match size of preview
+        transform = CGAffineTransformScale(transform, stickerScale, stickerScale)
+
+        // Translate
+        // Calculate the origin of the sticker. Note that in CoreImage (0,0) is at the bottom
+        let stickerOrigin = CGPoint(x: stickerCenter.x - absoluteStickerSize.width * xScale / 2, y: stickerCenter.y + absoluteStickerSize.height * yScale / 2)
+        transform = CGAffineTransformTranslate(transform, stickerOrigin.x / stickerScale, (originalInputImageSize.height - stickerOrigin.y) / stickerScale)
+
+        // Scale
+        transform = CGAffineTransformScale(transform, xScale, yScale)
+
+        // Rotate
+        transform = CGAffineTransformTranslate(transform, 0.5 * stickerImageSize.width, 0.5 * stickerImageSize.height)
+        transform = CGAffineTransformRotate(transform, -1 * rotation)
+        transform = CGAffineTransformTranslate(transform, -0.5 * stickerImageSize.width, -0.5 * stickerImageSize.height)
+
+        image = image.imageByApplyingTransform(transform)
+        image = image.imageByCroppingToRect(inputImageRect)
 
         return image
     }
 
-    #elseif os(OSX)
-
-    private func createStickerImage() -> NSImage {
-        let rect = inputImage!.extent
-        let imageSize = rect.size
-
-        let image = NSImage(size: imageSize)
-        image.lockFocus()
-        NSColor(white: 1, alpha: 0).setFill()
-        NSRectFill(CGRect(origin: CGPoint(), size: imageSize))
-
-        let context = NSGraphicsContext.currentContext()!.CGContext
-        drawStickerInContext(context, withImageOfSize: imageSize)
-
-        image.unlockFocus()
-
-        return image
-    }
-
-    #endif
-
-    // MARK:- rotation
+    // MARK: - Rotation
 
     public func rotateRight () {
         rotate(CGFloat(M_PI_2), negateX: true, negateY: false)
@@ -138,7 +143,7 @@ import CoreGraphics
         self.center.y += 0.5
     }
 
-    // MARK:- flipping
+    // MARK: - Flipping
 
     public func flipStickersHorizontal () {
         flipSticker(true)
@@ -191,30 +196,6 @@ import CoreGraphics
 
         let delta = axisAngle - angle
         self.transform = CGAffineTransformRotate(self.transform, delta * 2.0)
-    }
-
-    // MARK:- drawing
-
-    private func drawStickerInContext(context: CGContextRef, withImageOfSize imageSize: CGSize) {
-        CGContextSaveGState(context)
-
-        let originalSize = CGSize(width: round(imageSize.width / cropRect.width), height: round(imageSize.height / cropRect.height))
-        var center = CGPoint(x: self.center.x * originalSize.width, y: self.center.y * originalSize.height)
-        center.x -= (cropRect.origin.x * originalSize.width)
-        center.y -= (cropRect.origin.y * originalSize.height)
-
-        let size = self.absolutStickerSizeForImageSize(originalSize)
-        let imageRect = CGRect(origin: center, size: size)
-
-        // Move center to origin
-        CGContextTranslateCTM(context, imageRect.origin.x, imageRect.origin.y)
-        // Apply the transform
-        CGContextConcatCTM(context, self.transform)
-        // Move the origin back by half
-        CGContextTranslateCTM(context, imageRect.size.width * -0.5, imageRect.size.height * -0.5)
-
-        sticker?.drawInRect(CGRect(origin: CGPoint(), size: size))
-        CGContextRestoreGState(context)
     }
 }
 

--- a/imglyKit/Frontend/Editor/OverlayConverter.swift
+++ b/imglyKit/Frontend/Editor/OverlayConverter.swift
@@ -45,7 +45,7 @@ import UIKit
         var completeSize = containerView.bounds.size
         completeSize.width *= 1.0 / cropRect.width
         completeSize.height *= 1.0 / cropRect.height
-        let size = stickerFilter.absolutStickerSizeForImageSize(completeSize)
+        let size = stickerFilter.absoluteStickerSizeForImageSize(completeSize)
         imageView.frame.size = size
         var center = CGPoint(x: stickerFilter.center.x * completeSize.width,
             y: stickerFilter.center.y * completeSize.height)

--- a/imglyKit/Frontend/Editor/PathHelper.swift
+++ b/imglyKit/Frontend/Editor/PathHelper.swift
@@ -8,15 +8,17 @@
 
 import UIKit
 
-@objc(IMGLYPathHelper)  public class PathHelper: NSObject {
-    static public func clipCornersToOvalWidth(context: CGContextRef, width:CGFloat, height:CGFloat, ovalWidth: CGFloat, ovalHeight: CGFloat) {
+class PathHelper {
+    static func clipCornersToOvalWidth(context: CGContextRef, width: CGFloat, height: CGFloat, ovalWidth: CGFloat, ovalHeight: CGFloat) {
         var fw = CGFloat(0)
         var fh = CGFloat(0)
         let rect = CGRect(x: 0.0, y: 0.0, width: width, height: height)
+
         if ovalWidth == 0 || ovalHeight == 0 {
             CGContextAddRect(context, rect)
             return
         }
+
         CGContextSaveGState(context)
         CGContextTranslateCTM(context, CGRectGetMinX(rect), CGRectGetMinY(rect))
         CGContextScaleCTM(context, ovalWidth, ovalHeight)
@@ -30,5 +32,4 @@ import UIKit
         CGContextClosePath(context)
         CGContextRestoreGState(context)
     }
-
 }


### PR DESCRIPTION
Instead of generating a huge `UIImage` for each sticker and each text, we are now using `CIImage`s directly, which results in better CPU performance. Memory issues still need to be addressed.