### PR TITLE
Remove usage of dynamicType

### DIFF
--- a/imglyKit/Backend/FontImporter.swift
+++ b/imglyKit/Backend/FontImporter.swift
@@ -29,7 +29,7 @@ import CoreText
     }
 
     private func importFontsWithExtension(ext: String) {
-        let paths = NSBundle(forClass: self.dynamicType).pathsForResourcesOfType(ext, inDirectory: nil)
+        let paths = NSBundle(forClass: FontImporter.self).pathsForResourcesOfType(ext, inDirectory: nil)
         for fontPath in paths {
             let data: NSData? = NSFileManager.defaultManager().contentsAtPath(fontPath)
             var error: Unmanaged<CFError>?

--- a/imglyKit/Frontend/Editor/AlphaPickerView.swift
+++ b/imglyKit/Frontend/Editor/AlphaPickerView.swift
@@ -17,7 +17,7 @@ import UIKit
 
     private private(set) lazy var checkboardColor: UIColor = {
         var color = UIColor.whiteColor()
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: AlphaPickerView.self)
         if let image = UIImage(named: "checkerboard", inBundle: bundle, compatibleWithTraitCollection: nil) {
             color = UIColor(patternImage: image)
         }

--- a/imglyKit/Frontend/Editor/BoxGradientView.swift
+++ b/imglyKit/Frontend/Editor/BoxGradientView.swift
@@ -70,7 +70,7 @@ public struct Line {
     }
 
     public func configureCrossImageView() {
-        crossImageView.image = UIImage(named: "crosshair", inBundle: NSBundle(forClass: self.dynamicType), compatibleWithTraitCollection:nil)
+        crossImageView.image = UIImage(named: "crosshair", inBundle: NSBundle(forClass: BoxGradientView.self), compatibleWithTraitCollection:nil)
         crossImageView.userInteractionEnabled = true
         crossImageView.frame = CGRect(x: 0, y: 0, width: crossImageView.image!.size.width, height: crossImageView.image!.size.height)
         addSubview(crossImageView)

--- a/imglyKit/Frontend/Editor/CircleGradientView.swift
+++ b/imglyKit/Frontend/Editor/CircleGradientView.swift
@@ -59,7 +59,7 @@ import UIKit
     }
 
     public func configureCrossImageView() {
-        crossImageView.image = UIImage(named: "crosshair", inBundle: NSBundle(forClass: self.dynamicType), compatibleWithTraitCollection:nil)
+        crossImageView.image = UIImage(named: "crosshair", inBundle: NSBundle(forClass: CircleGradientView.self), compatibleWithTraitCollection:nil)
         crossImageView.userInteractionEnabled = true
         crossImageView.frame = CGRect(x: 0, y: 0, width: crossImageView.image!.size.width, height: crossImageView.image!.size.height)
         addSubview(crossImageView)

--- a/imglyKit/Frontend/Editor/CropEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/CropEditorViewController.swift
@@ -43,7 +43,7 @@ public let kMinimumCropSize = CGFloat(50)
     // MARK: - Properties
 
     public private(set) lazy var freeRatioButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: CropEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Free")
         button.imageView.image = UIImage(named: "icon_crop_custom", inBundle: bundle, compatibleWithTraitCollection: nil)
@@ -54,7 +54,7 @@ public let kMinimumCropSize = CGFloat(50)
         }()
 
     public private(set) lazy var oneToOneRatioButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: CropEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("1:1")
         button.imageView.image = UIImage(named: "icon_crop_square", inBundle: bundle, compatibleWithTraitCollection: nil)
@@ -65,7 +65,7 @@ public let kMinimumCropSize = CGFloat(50)
         }()
 
     public private(set) lazy var fourToThreeRatioButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: CropEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("4:3")
         button.imageView.image = UIImage(named: "icon_crop_4-3", inBundle: bundle, compatibleWithTraitCollection: nil)
@@ -76,7 +76,7 @@ public let kMinimumCropSize = CGFloat(50)
         }()
 
     public private(set) lazy var sixteenToNineRatioButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: CropEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("16:9")
         button.imageView.image = UIImage(named: "icon_crop_16-9", inBundle: bundle, compatibleWithTraitCollection: nil)

--- a/imglyKit/Frontend/Editor/CropRectComponent.swift
+++ b/imglyKit/Frontend/Editor/CropRectComponent.swift
@@ -69,7 +69,7 @@ import UIKit
     }
 
     private func setupAnchors() {
-        let anchorImage = UIImage(named: "crop_anchor", inBundle: NSBundle(forClass: self.dynamicType), compatibleWithTraitCollection:nil)
+        let anchorImage = UIImage(named: "crop_anchor", inBundle: NSBundle(forClass: CropRectComponent.self), compatibleWithTraitCollection:nil)
         topLeftAnchor = createAnchorWithImage(anchorImage)
         topRightAnchor = createAnchorWithImage(anchorImage)
         bottomLeftAnchor = createAnchorWithImage(anchorImage)

--- a/imglyKit/Frontend/Editor/FilterCollectionViewCell.swift
+++ b/imglyKit/Frontend/Editor/FilterCollectionViewCell.swift
@@ -24,7 +24,7 @@ class FilterCollectionViewCell: ImageCaptionCollectionViewCell {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .Center
         imageView.alpha = 0
-        imageView.image = UIImage(named: "icon_tick", inBundle: NSBundle(forClass: self.dynamicType), compatibleWithTraitCollection:nil)
+        imageView.image = UIImage(named: "icon_tick", inBundle: NSBundle(forClass: FilterCollectionViewCell.self), compatibleWithTraitCollection:nil)
         return imageView
     }()
 

--- a/imglyKit/Frontend/Editor/FocusEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/FocusEditorViewController.swift
@@ -26,7 +26,7 @@ import UIKit
     // MARK: - Properties
 
     public private(set) lazy var offButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: FocusEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Off")
         button.imageView.image = UIImage(named: "icon_focus_off", inBundle: bundle, compatibleWithTraitCollection: nil)
@@ -37,7 +37,7 @@ import UIKit
         }()
 
     public private(set) lazy var linearButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: FocusEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Linear")
         button.imageView.image = UIImage(named: "icon_focus_linear", inBundle: bundle, compatibleWithTraitCollection: nil)
@@ -48,7 +48,7 @@ import UIKit
         }()
 
     public private(set) lazy var radialButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: FocusEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Radial")
         button.imageView.image = UIImage(named: "icon_focus_radial", inBundle: bundle, compatibleWithTraitCollection: nil)

--- a/imglyKit/Frontend/Editor/StickersEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/StickersEditorViewController.swift
@@ -30,7 +30,7 @@ let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
     private var selectedView = UIImageView()
 
     public private(set) lazy var deleteButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: StickersEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_crop_custom", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -39,7 +39,7 @@ let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
     }()
 
     public private(set) lazy var flipHorizontalButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: StickersEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_crop_custom", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -48,7 +48,7 @@ let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
     }()
 
     public private(set) lazy var flipVerticalButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: StickersEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_crop_custom", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -57,7 +57,7 @@ let kStickersCollectionViewCellReuseIdentifier = "StickersCollectionViewCell"
     }()
 
     public private(set) lazy var bringToFrontButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: StickersEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_crop_custom", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/imglyKit/Frontend/Editor/TextEditorViewController.swift
+++ b/imglyKit/Frontend/Editor/TextEditorViewController.swift
@@ -40,7 +40,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     private let lowerOverlayButtonConstant = CGFloat(20)
 
     public private(set) lazy var addTextButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_add", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -49,7 +49,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var deleteTextButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_delete", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -58,7 +58,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var acceptColorButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_confirm", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -67,7 +67,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var rejectColorButton: UIButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = UIButton(type: UIButtonType.Custom)
         button.setImage(UIImage(named: "icon_cancel", inBundle: bundle, compatibleWithTraitCollection: nil), forState: .Normal)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -76,7 +76,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var selectTextFontButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Font")
         button.imageView.image = UIImage(named: "icon_crop_custom", inBundle: bundle, compatibleWithTraitCollection: nil)
@@ -86,7 +86,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var selectTextColorButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Text")
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -98,7 +98,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var selectBackgroundColorButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Back")
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -110,7 +110,7 @@ private let kMinimumFontSize = CGFloat(12.0)
     }()
 
     public private(set) lazy var bringToFrontButton: ImageCaptionButton = {
-        let bundle = NSBundle(forClass: self.dynamicType)
+        let bundle = NSBundle(forClass: TextEditorViewController.self)
         let button = ImageCaptionButton()
         button.textLabel.text = Localize("Bring to front")
         button.imageView.image = UIImage(named: "icon_bringtofront", inBundle: bundle, compatibleWithTraitCollection: nil)


### PR DESCRIPTION
Using dynamicType to get the bundle for a class (obviously) returns the bundle of the class that the original class was replaced with. This caused an error where icons would not be displayed when a user replaced a class with his own. All instances of dynamicType have now been replaced with the actual class.