### PR TITLE
Update effect filters to use `CIColorCubeWithColorSpace`

### DIFF
--- a/imglyKit/Backend/Processing/PhotoProcessor.swift
+++ b/imglyKit/Backend/Processing/PhotoProcessor.swift
@@ -117,9 +117,9 @@ All types of response-filters.
 
         var options = [String: AnyObject]()
 
-        if let colorspace = CGColorSpaceCreateDeviceRGB() {
-            options[kCIContextWorkingColorSpace] = colorspace
-        }
+        //if let colorspace = CGColorSpaceCreateDeviceRGB() {
+        //    options[kCIContextWorkingColorSpace] = colorspace
+        //}
 
         let filteredCIImage = processWithCIImage(coreImage, filters: filters)
         let filteredCGImage = CIContext(options: options).createCGImage(filteredCIImage!, fromRect: filteredCIImage!.extent)

--- a/imglyKit/Backend/Processing/PhotoProcessor.swift
+++ b/imglyKit/Backend/Processing/PhotoProcessor.swift
@@ -115,14 +115,8 @@ All types of response-filters.
             return nil
         }
 
-        var options = [String: AnyObject]()
-
-        //if let colorspace = CGColorSpaceCreateDeviceRGB() {
-        //    options[kCIContextWorkingColorSpace] = colorspace
-        //}
-
         let filteredCIImage = processWithCIImage(coreImage, filters: filters)
-        let filteredCGImage = CIContext(options: options).createCGImage(filteredCIImage!, fromRect: filteredCIImage!.extent)
+        let filteredCGImage = CIContext(options: nil).createCGImage(filteredCIImage!, fromRect: filteredCIImage!.extent)
         return UIImage(CGImage: filteredCGImage, scale: 1.0, orientation: imageOrientation)
     }
 

--- a/imglyKit/Backend/Processing/Response Filters/ResponseFilter.swift
+++ b/imglyKit/Backend/Processing/Response Filters/ResponseFilter.swift
@@ -80,7 +80,9 @@ import QuartzCore
             if let colorCubeData = colorCubeData, filter = CIFilter(name: "CIColorCubeWithColorSpace") {
                 filter.setValue(colorCubeData, forKey: "inputCubeData")
                 filter.setValue(64, forKey: "inputCubeDimension")
-                filter.setValue(CGColorSpaceCreateDeviceRGB(), forKey: "inputColorSpace")
+                if let colorSpace = CGColorSpaceCreateDeviceRGB() {
+                    filter.setValue(colorSpace, forKey: "inputColorSpace")
+                }
                 filter.setValue(inputImage, forKey: kCIInputImageKey)
                 outputImage = filter.outputImage
             } else {

--- a/imglyKit/Backend/Processing/Response Filters/ResponseFilter.swift
+++ b/imglyKit/Backend/Processing/Response Filters/ResponseFilter.swift
@@ -77,9 +77,10 @@ import QuartzCore
         var outputImage: CIImage?
 
         autoreleasepool {
-            if let colorCubeData = colorCubeData, filter = CIFilter(name: "CIColorCube") {
+            if let colorCubeData = colorCubeData, filter = CIFilter(name: "CIColorCubeWithColorSpace") {
                 filter.setValue(colorCubeData, forKey: "inputCubeData")
                 filter.setValue(64, forKey: "inputCubeDimension")
+                filter.setValue(CGColorSpaceCreateDeviceRGB(), forKey: "inputColorSpace")
                 filter.setValue(inputImage, forKey: kCIInputImageKey)
                 outputImage = filter.outputImage
             } else {

--- a/imglyKit/Frontend/Camera/SampleBufferController.swift
+++ b/imglyKit/Frontend/Camera/SampleBufferController.swift
@@ -34,12 +34,12 @@ class SampleBufferController: NSObject {
     init(videoPreviewView: GLKView) {
         self.videoPreviewView = videoPreviewView
 
-        let options: [String: AnyObject]?
-        if let colorSpace = CGColorSpaceCreateDeviceRGB() {
-            options = [kCIContextWorkingColorSpace: colorSpace]
+        let options: [String: AnyObject]? = nil
+      /*  if let colorSpace = CGColorSpaceCreateDeviceRGB() {
+        options = [kCIContextWorkingColorSpace: colorSpace]
         } else {
             options = nil
-        }
+        }*/
 
         ciContext = CIContext(EAGLContext: self.videoPreviewView.context, options: options)
 

--- a/imglyKit/Frontend/Camera/SampleBufferController.swift
+++ b/imglyKit/Frontend/Camera/SampleBufferController.swift
@@ -33,15 +33,7 @@ class SampleBufferController: NSObject {
 
     init(videoPreviewView: GLKView) {
         self.videoPreviewView = videoPreviewView
-
-        let options: [String: AnyObject]? = nil
-      /*  if let colorSpace = CGColorSpaceCreateDeviceRGB() {
-        options = [kCIContextWorkingColorSpace: colorSpace]
-        } else {
-            options = nil
-        }*/
-
-        ciContext = CIContext(EAGLContext: self.videoPreviewView.context, options: options)
+        ciContext = CIContext(EAGLContext: self.videoPreviewView.context, options: nil)
 
         super.init()
     }


### PR DESCRIPTION
Effect filters now use a `CIColorCubeWithColorSpace` `CIFilter` instead of `CIColorCube` to immediately specify a color space.